### PR TITLE
Redmi Note 7

### DIFF
--- a/Root
+++ b/Root
@@ -1,0 +1,43 @@
+# Android fstab file.
+
+# The filesystem that contains the filesystem checker binary (typically /system) cannot
+
+# specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+
+# mount point    fstype     device                 device2                        flags
+
+/boot            emmc              /dev/block/bootdevice/by-name/boot       flags=slotselect;backup=1;flashimg=1
+
+/system          ext4              /dev/block/bootdevice/by-name/system     flags=slotselect;backup=1;flashimg=1
+
+/system_image    emmc              /dev/block/bootdevice/by-name/system     flags=slotselect;backup=1
+
+/splash          emmc              /dev/block/bootdevice/by-name/splash     flags=display="Boot Logo";backup=1;flashimg=1
+
+/vendor          ext4              /dev/block/bootdevice/by-name/vendor     flags=slotselect;display="Vendor";backup=1;flashimg=1;wipeingui
+
+/vendor_image    emmc              /dev/block/bootdevice/by-name/vendor     flags=slotselect;backup=1
+
+/data            f2fs              /dev/block/bootdevice/by-name/userdata   flags=encryptable=footer;backup=1;
+
+/persist         ext4              /dev/block/bootdevice/by-name/persist    flags=display="Persist";backup=1;flashimg=1
+
+/bt_firmware     vfat              /dev/block/bootdevice/by-name/bluetooth  flags=display="Bluetooth";backup=1;slotselect;flashimg=1
+
+/misc            emmc              /dev/block/bootdevice/by-name/misc
+
+/modem           emmc              /dev/block/bootdevice/by-name/modem      flags=slotselect;backup=1;display="Modem";flashimg=1
+
+/firmware        vfat              /dev/block/bootdevice/by-name/modem      flags=display="Firmware";slotselect;backup=1;mounttodecrypt;fsflags=context=u:object_r:firmware_file:s0
+
+/efs1            emmc              /dev/block/bootdevice/by-name/modemst1   flags=backup=1;display=EFS;flashimg=1
+
+/efs2            emmc              /dev/block/bootdevice/by-name/modemst2   flags=backup=1;subpartitionof=/efs1
+
+/efsc            emmc              /dev/block/bootdevice/by-name/fsc        flags=backup=1;subpartitionof=/efs1
+
+/efsg            emmc              /dev/block/bootdevice/by-name/fsg        flags=backup=1;subpartitionof=/efs1
+
+# Removable storage
+
+/usb-otg         auto              /dev/block/sda1         /dev/block/sda   flags=removable;storage;display="USB OTG"


### PR DESCRIPTION

# Copyright (c) 2009-2012, 2014-2015, The Linux Foundation. All rights reserved.
#
# Redistribution and use in source and binary forms, with or without
# modification, are permitted provided that the following conditions are met:
#     * Redistributions of source code must retain the above copyright
#       notice, this list of conditions and the following disclaimer.
#     * Redistributions in binary form must reproduce the above copyright
#       notice, this list of conditions and the following disclaimer in the
#       documentation and/or other materials provided with the distribution.
#     * Neither the name of The Linux Foundation nor
#       the names of its contributors may be used to endorse or promote
#       products derived from this software without specific prior written
#       permission.
#
# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
# IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
# NON-INFRINGEMENT ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
#

on fs
    wait /dev/block/platform/soc/${ro.boot.bootdevice}
    symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
    chmod 0660 /dev/qseecom
    chown system drmrpc /dev/qseecom
    chmod 0664 /dev/ion
    chown system system /dev/ion
    install_keyring

# Separate copy needed to use /sbin/linker64 instead of /system/bin/linker64
service sbinqseecomd /sbin/qseecomd
    user root
    group root
    disabled
    seclabel u:r:recovery:s0

service hwservicemanager /sbin/hwservicemanager
    user root
    group root
    disabled
    onrestart setprop hwservicemanager.ready false
    seclabel u:r:recovery:s0

service servicemanager /sbin/servicemanager
    user root
    group root readproc
    disabled
    seclabel u:r:recovery:s0

service prepdecrypt /sbin/prepdecrypt.sh
    oneshot
    disabled
    user root
    group root
    seclabel u:r:recovery:s0	

service keystore_auth /sbin/keystore_auth
    oneshot
    user system
    group root
    disabled
    seclabel u:r:recovery:s0

# keystore is started and stopped on demand by TWRP
service keystore /sbin/keystore /tmp/misc/keystore
    user root
    group root drmrpc readproc
    disabled
    seclabel u:r:recovery:s0

service gatekeeper-1-0 /sbin/android.hardware.gatekeeper@1.0-service-qti
    user root
    group root
    disabled
    seclabel u:r:recovery:s0

service keymaster-3-0 /sbin/android.hardware.keymaster@3.0-service-qti
    user root
    group root
    disabled
    seclabel u:r:recovery:s0

on boot
    setprop sys.usb.config adb

on init
    start hwservicemanager
    setprop crypto.ready 1

on property:crypto.ready=0
    stop sbinqseecomd
    stop keymaster-3-0
    stop gatekeeper-1-0
    stop servicemanager

on property:crypto.ready=1
    start sbinqseecomd

on property:sys.listeners.registered=true
    start keymaster-3-0
    start gatekeeper-1-0
    start servicemanager

    mkdir /config
    mount configfs none /config
    mkdir /config/usb_gadget/g1 0770 shell shell
    write /config/usb_gadget/g1/bcdUSB 0x0200
    write /config/usb_gadget/g1/idVendor 0x18d1
    write /config/usb_gadget/g1/idProduct 0xd001
    mkdir /config/usb_gadget/g1/strings/0x409 0770 shell shell
    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
    write /config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.manufacturer}
    write /config/usb_gadget/g1/strings/0x409/product ${ro.product.model}
    mkdir /config/usb_gadget/g1/functions/ffs.adb
    write /config/usb_gadget/g1/os_desc/use 1
    write /config/usb_gadget/g1/os_desc/b_vendor_code 0x1
    write /config/usb_gadget/g1/os_desc/qw_sign "MSFT100"
    setprop sys.usb.configfs 1

on property:ro.boot.usbcontroller=*
    setprop sys.usb.controller ${ro.boot.usbcontroller}

on property:sys.usb.ffs.ready=1
    mkdir /config/usb_gadget/g1/configs/b.1 0777 shell shell
    symlink /config/usb_gadget/g1/configs/b.1 /config/usb_gadget/g1/os_desc/b.1
    mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
    write /config/usb_gadget/g1/UDC ${sys.usb.controller}	

on init 
    write /sys/class/backlight/panel0-backlight/brightness 200### 